### PR TITLE
Scripts for downloading HAR dataset and organising it into train-val-test files

### DIFF
--- a/tf/examples/EMI-RNN/fetch_har.py
+++ b/tf/examples/EMI-RNN/fetch_har.py
@@ -53,7 +53,7 @@ def downloadData(workingDir, downloadDir):
 def processData(workingDir, downloadDir):
     path = workingDir + '/' + downloadDir
     path = os.path.abspath(path)
-    generateData(path, seed=42)
+    generateData(path)
 
 if __name__ == '__main__':
     if BASH is True:

--- a/tf/examples/EMI-RNN/fetch_har.py
+++ b/tf/examples/EMI-RNN/fetch_har.py
@@ -21,6 +21,7 @@ BASH = True
 workingDir = './'
 downloadDir = 'HAR'
 linkData = 'https://archive.ics.uci.edu/ml/machine-learning-databases/00240/UCI%20HAR%20Dataset.zip'
+from helpermethods import *
 
 def downloadData(workingDir, downloadDir):
     def runcommand(command, splitChar=' '):
@@ -50,26 +51,9 @@ def downloadData(workingDir, downloadDir):
     return True
 
 def processData(workingDir, downloadDir):
-    def loadLibSVMFile(file):
-        data = load_svmlight_file(file)
-        features = data[0]
-        labels = data[1]
-        retMat = np.zeros([features.shape[0], features.shape[1] + 1])
-        retMat[:, 0] = labels
-        retMat[:, 1:] = features.todense()
-        return retMat
-
     path = workingDir + '/' + downloadDir
     path = os.path.abspath(path)
-    trf = path + '/train.txt'
-    tsf = path + '/test.txt'
-    assert os.path.isfile(trf), 'File not found: %s' % trf
-    assert os.path.isfile(tsf), 'File not found: %s' % tsf
-    train = loadLibSVMFile(trf)
-    test = loadLibSVMFile(tsf)
-    np.save(path + '/train.npy', train)
-    np.save(path + '/test.npy', test)
-
+    generateData(path, seed=42)
 
 if __name__ == '__main__':
     if BASH is True:
@@ -78,6 +62,6 @@ if __name__ == '__main__':
         print("provided in this script.")
         if not downloadData(workingDir, downloadDir):
             exit('Download failed')
-    # print("Procesing data")
-    # processData(workingDir, downloadDir)
+    print("Procesing data")
+    processData(workingDir, downloadDir)
     print("Done")

--- a/tf/examples/EMI-RNN/fetch_har.py
+++ b/tf/examples/EMI-RNN/fetch_har.py
@@ -15,13 +15,13 @@ import subprocess
 import os
 import numpy as np
 import sys
+from helpermethods import *
 
 BASH = True
 
 workingDir = './'
 downloadDir = 'HAR'
 linkData = 'https://archive.ics.uci.edu/ml/machine-learning-databases/00240/UCI%20HAR%20Dataset.zip'
-from helpermethods import *
 
 def downloadData(workingDir, downloadDir):
     def runcommand(command, splitChar=' '):

--- a/tf/examples/EMI-RNN/helpermethods.py
+++ b/tf/examples/EMI-RNN/helpermethods.py
@@ -1,4 +1,5 @@
 # creates x_train, y_train, x_test, y_test, x_val, y_val npy files. val set is created after cutting out a user provided fraction from train set.
+# reference : https://github.com/guillaume-chevalier/LSTM-Human-Activity-Recognition
 
 import numpy as np
 import os

--- a/tf/examples/EMI-RNN/helpermethods.py
+++ b/tf/examples/EMI-RNN/helpermethods.py
@@ -1,5 +1,9 @@
-# creates x_train, y_train, x_test, y_test, x_val, y_val npy files. val set is created after cutting out a user provided fraction from train set.
-# reference : https://github.com/guillaume-chevalier/LSTM-Human-Activity-Recognition
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+# 
+# Helper methods to generate training, validation and test splits from the UCI HAR dataset. 
+# Each split consists of a separate set of users.
+# Reference : https://github.com/guillaume-chevalier/LSTM-Human-Activity-Recognition
 
 import numpy as np
 import os

--- a/tf/examples/EMI-RNN/helpermethods.py
+++ b/tf/examples/EMI-RNN/helpermethods.py
@@ -8,71 +8,62 @@
 import numpy as np
 import os
 
-def generateIndicesForSplits(extractedDir):
-	f = open(extractedDir +'/UCI HAR Dataset/train/subject_train.txt')
-	subjects = []
-	for line in f:
-		subject = line.strip().split()
-		subjects.append(int(subject[0]))
-	subjects = np.array(subjects)
+def generateIndicesForSplits(path='./HAR/UCI HAR Dataset/train/subject_train.txt'):
+    f = open(path)
+    subjects = []
+    for line in f:
+        subject = line.strip().split()
+        subjects.append(int(subject[0]))
+    subjects = np.array(subjects)
 
-	# get unique subjects
-	numSubjects = np.unique(subjects)
-	# print ("Unique subjects are", numSubjects)
+    # get unique subjects
+    numSubjects = np.unique(subjects)
 
-	# shuffle amongst train subjects so that difficult/easy subjects spread in both val and train
-	np.random.shuffle(numSubjects)
-	# print ("Unique subjects after shuffling are", numSubjects)
+    # shuffle amongst train subjects so that difficult/easy subjects spread in both val and train
+    np.random.shuffle(numSubjects)
 
-	l = len(numSubjects)
+    l = len(numSubjects)
 
-	splitRatio = 0.1
-	valSplit = int(l*splitRatio + 1)
+    splitRatio = 0.1
+    valSplit = int(l * splitRatio + 1)
 
-	valSubjects = numSubjects[:valSplit]
-	trainSubjects = numSubjects[valSplit:]
+    valSubjects = numSubjects[:valSplit]
+    trainSubjects = numSubjects[valSplit:]
 
-	# print ("Train subjects are", trainSubjects)
-	# print ("Val subjects are", valSubjects)
+    trainSubjectIndices = []
+    valSubjectIndices = []
 
-	trainSubjectIndices = []
-	valSubjectIndices = []
+    for i, subject in enumerate(subjects):
+        if subject in trainSubjects:
+            trainSubjectIndices.append(i)
+        elif subject in valSubjects:
+            valSubjectIndices.append(i)
+        else:
+            raise Exception("some bug in your code")
 
-	for i, subject in enumerate(subjects):
-		if subject in trainSubjects:
-			trainSubjectIndices.append(i)
-		elif subject in valSubjects:
-			valSubjectIndices.append(i)
-		else:
-			raise Exception("some bug in your code")
+    # assert that train/val different
+    for x in trainSubjectIndices:
+        assert x not in valSubjectIndices
 
-	# assert that train/val different
-	for x in trainSubjectIndices:
-		assert x not in valSubjectIndices
+    trainSubjectIndices = np.array(trainSubjectIndices)
+    valSubjectIndices = np.array(valSubjectIndices)
 
-	trainSubjectIndices = np.array(trainSubjectIndices)
-	valSubjectIndices = np.array(valSubjectIndices)
+    # shuffle more, so that readings not grouped by a subject
+    # therefore, no need to shuffle after slicing from read dataset, as we are shuffling here
+    idx = np.arange(len(trainSubjectIndices))
+    np.random.shuffle(idx)
+    trainSubjectIndices = trainSubjectIndices[idx]
 
-	# shuffle more, so that readings not grouped by a subject
-	# therefore, no need to shuffle after slicing from read dataset, as we are shuffling here
-	idx = np.arange(len(trainSubjectIndices))
-	np.random.seed(42)
-	np.random.shuffle(idx)
-	trainSubjectIndices = trainSubjectIndices[idx]
+    idx = np.arange(len(valSubjectIndices))
+    np.random.shuffle(idx)
+    valSubjectIndices = valSubjectIndices[idx]
 
-	idx = np.arange(len(valSubjectIndices))
-	np.random.seed(42)
-	np.random.shuffle(idx)
-	valSubjectIndices = valSubjectIndices[idx]
+    assert len(trainSubjectIndices) + len(valSubjectIndices) == len(subjects)
 
-	# print (len(trainSubjectIndices), len(valSubjectIndices))
-	assert len(trainSubjectIndices) + len(valSubjectIndices) == len(subjects)
+    return trainSubjectIndices, valSubjectIndices
 
-	return trainSubjectIndices, valSubjectIndices
-
-# painfully read files
 def readData(extractedDir):
-	INPUT_SIGNAL_TYPES = [
+    INPUT_SIGNAL_TYPES = [
     "body_acc_x_",
     "body_acc_y_",
     "body_acc_z_",
@@ -82,143 +73,129 @@ def readData(extractedDir):
     "total_acc_x_",
     "total_acc_y_",
     "total_acc_z_"
-	]
+    ]
 
-	# Output classes to learn how to classify
-	LABELS = [
-	    "WALKING", 
-	    "WALKING_UPSTAIRS", 
-	    "WALKING_DOWNSTAIRS", 
-	    "SITTING", 
-	    "STANDING", 
-	    "LAYING"
-	] 
-	DATASET_PATH = extractedDir + "/UCI HAR Dataset/"
-	TRAIN = "train/"
-	TEST = "test/"
-	# Load "X" (the neural network's training and testing inputs)
+    # Output classes to learn how to classify
+    LABELS = [
+        "WALKING", 
+        "WALKING_UPSTAIRS", 
+        "WALKING_DOWNSTAIRS", 
+        "SITTING", 
+        "STANDING", 
+        "LAYING"
+    ] 
+    DATASET_PATH = extractedDir + "/UCI HAR Dataset/"
+    TRAIN = "train/"
+    TEST = "test/"
+    # Load "X" (the neural network's training and testing inputs)
 
-	def load_X(X_signals_paths):
-	    X_signals = []
-	    
-	    for signal_type_path in X_signals_paths:
-	        file = open(signal_type_path, 'r')
-	        # Read dataset from disk, dealing with text files' syntax
-	        X_signals.append(
-	            [np.array(serie, dtype=np.float32) for serie in [
-	                row.replace('  ', ' ').strip().split(' ') for row in file
-	            ]]
-	        )
-	        file.close()
-	    
-	    return np.transpose(np.array(X_signals), (1, 2, 0))
+    def load_X(X_signals_paths):
+        X_signals = []
+        
+        for signal_type_path in X_signals_paths:
+            file = open(signal_type_path, 'r')
+            # Read dataset from disk, dealing with text files' syntax
+            X_signals.append(
+                [np.array(serie, dtype=np.float32) for serie in [
+                    row.replace('  ', ' ').strip().split(' ') for row in file
+                ]]
+            )
+            file.close()
+        
+        return np.transpose(np.array(X_signals), (1, 2, 0))
 
-	X_train_signals_paths = [
-	    DATASET_PATH + TRAIN + "Inertial Signals/" + signal + "train.txt" for signal in INPUT_SIGNAL_TYPES
-	]
-	X_test_signals_paths = [
-	    DATASET_PATH + TEST + "Inertial Signals/" + signal + "test.txt" for signal in INPUT_SIGNAL_TYPES
-	]
+    X_train_signals_paths = [
+        DATASET_PATH + TRAIN + "Inertial Signals/" + signal + "train.txt" for signal in INPUT_SIGNAL_TYPES
+    ]
+    X_test_signals_paths = [
+        DATASET_PATH + TEST + "Inertial Signals/" + signal + "test.txt" for signal in INPUT_SIGNAL_TYPES
+    ]
 
-	x_train_val_combined = load_X(X_train_signals_paths)
-	x_test = load_X(X_test_signals_paths)
-
-
-	# Load "y" (the neural network's training and testing outputs)
-
-	def load_y(y_path):
-	    file = open(y_path, 'r')
-	    # Read dataset from disk, dealing with text file's syntax
-	    y_ = np.array(
-	        [elem for elem in [
-	            row.replace('  ', ' ').strip().split(' ') for row in file
-	        ]], 
-	        dtype=np.int32
-	    )
-	    file.close()
-	    
-	    # Substract 1 to each output class for friendly 0-based indexing 
-	    return y_ - 1
-
-	y_train_path = DATASET_PATH + TRAIN + "y_train.txt"
-	y_test_path = DATASET_PATH + TEST + "y_test.txt"
-
-	y_train_val_combined = load_y(y_train_path)
-	y_test = load_y(y_test_path)
-
-	return x_train_val_combined, y_train_val_combined, x_test, y_test
+    x_train_val_combined = load_X(X_train_signals_paths)
+    x_test = load_X(X_test_signals_paths)
 
 
-def generateData(extractedDir, seed=None):
-	if seed is not None:
-		np.random.seed(seed)
-	x_train_val_combined, y_train_val_combined, x_test, y_test = readData(extractedDir)
-	timesteps = x_train_val_combined.shape[-2]
-	feats = x_train_val_combined.shape[-1]
+    # Load "y" (the neural network's training and testing outputs)
 
-	trainSubjectIndices, valSubjectIndices = generateIndicesForSplits(extractedDir)
+    def load_y(y_path):
+        file = open(y_path, 'r')
+        # Read dataset from disk, dealing with text file's syntax
+        y_ = np.array(
+            [elem for elem in [
+                row.replace('  ', ' ').strip().split(' ') for row in file
+            ]], 
+            dtype=np.int32
+        )
+        file.close()
+        
+        # Substract 1 to each output class for friendly 0-based indexing 
+        return y_ - 1
 
-	x_train = x_train_val_combined[trainSubjectIndices]
-	y_train = y_train_val_combined[trainSubjectIndices]
-	x_val = x_train_val_combined[valSubjectIndices]
-	y_val = y_train_val_combined[valSubjectIndices]
+    y_train_path = DATASET_PATH + TRAIN + "y_train.txt"
+    y_test_path = DATASET_PATH + TEST + "y_test.txt"
 
-	# normalization
-	x_train = np.reshape(x_train, [-1, feats])
-	mean = np.mean(x_train, axis=0)
-	std = np.std(x_train, axis=0)
+    y_train_val_combined = load_y(y_train_path)
+    y_test = load_y(y_test_path)
 
-	# normalize train
-	x_train = x_train - mean
-	x_train = x_train / std
-	x_train = np.reshape(x_train, [-1, timesteps, feats])
+    return x_train_val_combined, y_train_val_combined, x_test, y_test
 
-	# normalize val
-	x_val = np.reshape(x_val, [-1, feats])
-	x_val = x_val - mean
-	x_val = x_val / std
-	x_val = np.reshape(x_val, [-1, timesteps, feats])
+def one_hot(y, numOutput):
+    y = np.reshape(y, [-1])
+    ret = np.zeros([y.shape[0], numOutput])
+    for i, label in enumerate(y):
+        ret[i, label] = 1
+    return ret
 
-	# normalize test
-	x_test = np.reshape(x_test, [-1, feats])
-	x_test = x_test - mean
-	x_test = x_test / std
-	x_test = np.reshape(x_test, [-1, timesteps, feats])
 
-	# shuffle test, as this was remaining
-	idx = np.arange(len(x_test))
-	np.random.shuffle(idx)
-	x_test = x_test[idx]
-	y_test = y_test[idx]
+def generateData(extractedDir):
+    x_train_val_combined, y_train_val_combined, x_test, y_test = readData(extractedDir)
+    timesteps = x_train_val_combined.shape[-2]
+    feats = x_train_val_combined.shape[-1]
 
-	# one-hot encoding of labels
-	numOutput = 6
+    trainSubjectIndices, valSubjectIndices = generateIndicesForSplits()
 
-	one_hot = np.zeros([y_train.shape[0], numOutput])
-	for i, label in enumerate(y_train):
-	    one_hot[i][label[0]] = 1
-	y_train = one_hot
+    x_train = x_train_val_combined[trainSubjectIndices]
+    y_train = y_train_val_combined[trainSubjectIndices]
+    x_val = x_train_val_combined[valSubjectIndices]
+    y_val = y_train_val_combined[valSubjectIndices]
 
-	one_hot = np.zeros([y_test.shape[0], numOutput])
-	for i, label in enumerate(y_test):
-	    one_hot[i][label[0]] = 1
-	y_test = one_hot
+    # normalization
+    x_train = np.reshape(x_train, [-1, feats])
+    mean = np.mean(x_train, axis=0)
+    std = np.std(x_train, axis=0)
 
-	one_hot = np.zeros([y_val.shape[0], numOutput])
-	for i, label in enumerate(y_val):
-	    one_hot[i][label[0]] = 1
-	y_val = one_hot
+    # normalize train
+    x_train = x_train - mean
+    x_train = x_train / std
+    x_train = np.reshape(x_train, [-1, timesteps, feats])
 
-	# print("x_train shape", x_train.shape)
-	# print("y_train shape", y_train.shape)
-	# print("x_test shape", x_test.shape)
-	# print("y_test shape", y_test.shape)
-	# print("x_val shape", x_val.shape)
-	# print("y_val shape", y_val.shape)
+    # normalize val
+    x_val = np.reshape(x_val, [-1, feats])
+    x_val = x_val - mean
+    x_val = x_val / std
+    x_val = np.reshape(x_val, [-1, timesteps, feats])
 
-	np.save(extractedDir + "/x_train", x_train)
-	np.save(extractedDir + "/y_train", y_train)
-	np.save(extractedDir + "/x_test", x_test)
-	np.save(extractedDir + "/y_test", y_test)
-	np.save(extractedDir + "/x_val", x_val)
-	np.save(extractedDir + "/y_val", y_val)
+    # normalize test
+    x_test = np.reshape(x_test, [-1, feats])
+    x_test = x_test - mean
+    x_test = x_test / std
+    x_test = np.reshape(x_test, [-1, timesteps, feats])
+
+    # shuffle test, as this was remaining
+    idx = np.arange(len(x_test))
+    np.random.shuffle(idx)
+    x_test = x_test[idx]
+    y_test = y_test[idx]
+
+    # one-hot encoding of labels
+    numOutput = 6
+    y_train = one_hot(y_train, numOutput)
+    y_val = one_hot(y_val, numOutput)
+    y_test = one_hot(y_test, numOutput)
+    
+    np.save(extractedDir + "/x_train", x_train)
+    np.save(extractedDir + "/y_train", y_train)
+    np.save(extractedDir + "/x_test", x_test)
+    np.save(extractedDir + "/y_test", y_test)
+    np.save(extractedDir + "/x_val", x_val)
+    np.save(extractedDir + "/y_val", y_val)


### PR DESCRIPTION
Adding scripts for downloading UCI HAR dataset from the internet and organising it into train-val-test .npy splits. Every split has a separate set of users, and the same user data is not part of two splits. Running fetch_har.py downloads and extracts the dataset and generates train-val-test .npy files in the extracted directory.