### PR TITLE
Remove an unnecessary null pointer check in Destructor of ProtoNNPredictor.cpp Class

### DIFF
--- a/cpp/src/ProtoNN/ProtoNNPredictor.cpp
+++ b/cpp/src/ProtoNN/ProtoNNPredictor.cpp
@@ -261,8 +261,7 @@ void ProtoNNPredictor::setFromArgs(const int argc, const char** argv)
 
 ProtoNNPredictor::~ProtoNNPredictor()
 {
-  if(dataPoint)
-    delete[] dataPoint;
+  delete[] dataPoint;
 }
 
 FP_TYPE ProtoNNPredictor::testDenseDataPoint(


### PR DESCRIPTION
According to [1], the "C++ language guarantees that delete p will do nothing if p is null", so we could avoid reductant if.

```
if (p != nullptr)   // or just "if (p)"
  delete p;
```

Issue Fixed: https://github.com/Microsoft/EdgeML/issues/48

Reference: 
[1] https://isocpp.org/wiki/faq/freestore-mgmt#delete-handles-null