### PR TITLE
Free dynamically alloc'd memory.

### DIFF
--- a/cpp/src/Bonsai/BonsaiPredictor.cpp
+++ b/cpp/src/Bonsai/BonsaiPredictor.cpp
@@ -317,6 +317,10 @@ void BonsaiPredictor::batchEvaluate(
   std::ofstream allDumper(dataDir + "/BonsaiResults" + "/resultDump", std::ofstream::out | std::ofstream::app);
   allDumper << totalNonZeros() << " " << accuracy << " " << currResultsPath << "\n";
   allDumper.close();
+
+  delete[] scoreArray;
+  delete[] trainvals;
+  delete[] label;
 }
 
 size_t BonsaiPredictor::totalNonZeros()


### PR DESCRIPTION
`BonsaiPredictor::batchEvaluate()` dynamically allocates memory but does not attempt to free it. This commit addresses this.