### PR TITLE
FastGRNNCUDA: Contiguous Allocation after Transpose

### DIFF
--- a/pytorch/edgeml_pytorch/graph/rnn.py
+++ b/pytorch/edgeml_pytorch/graph/rnn.py
@@ -1172,7 +1172,7 @@ class FastGRNNCUDA(nn.Module):
     def forward(self, input, hiddenState, cell_state=None):
         # input: [timesteps, batch, features, state_size]
         if self.batch_first:
-            input = input.transpose(0, 1)
+            input = input.transpose(0, 1).contiguous()
         if not input.is_cuda:
             input = input.to(self.device)
         if hiddenState is None:


### PR DESCRIPTION
The tensor returned by `.transpose()` in PyTorch may not always be contiguous, but the FastGRNN CUDA kernel expects the input to be contiguous, thus causing issues when batch_first is set to true.  

Simple fix is to call `.contiguous()` on the returned tensor to ensure the input tensor to the kernel is contiguous. 