### PR TITLE
FastGRNNCUDA: batch_first fixes

### DIFF
--- a/pytorch/edgeml_pytorch/cuda/fastgrnn_cuda_kernel.cu
+++ b/pytorch/edgeml_pytorch/cuda/fastgrnn_cuda_kernel.cu
@@ -406,7 +406,7 @@ std::vector<torch::Tensor> fastgrnn_unroll_cuda_forward(
             zeta.packed_accessor<scalar_t,2,torch::RestrictPtrTraits,size_t>(),
             prev_h.packed_accessor<scalar_t,2,torch::RestrictPtrTraits,size_t>());
         }));
-      hidden_states[t] = new_h;
+      hidden_states[t].copy_(new_h);
       z_s[t] = z;
       h_prime_s[t] = h_prime;
       prev_h = new_h;

--- a/pytorch/edgeml_pytorch/graph/rnn.py
+++ b/pytorch/edgeml_pytorch/graph/rnn.py
@@ -1179,7 +1179,7 @@ class FastGRNNCUDA(nn.Module):
 
     def forward(self, input, hiddenState=None, cell_state=None):
         '''
-            input: [timesteps, batch, features]; hiddenState: [state_size]
+            input: [timesteps, batch, features]; hiddenState: [batch, state_size]
             hiddenState is set to zeros if not provided. 
         '''
         if self.batch_first is True:


### PR DESCRIPTION
The current implementation does not transpose the result appropriately based on the batch_first argument. 

This PR contains a fix for that, and a small fix in the cuda code which was possibly causing errors in adding the layer to other architectures. The hiddenState argument in the layer is also set to None as default to match behaviour with torch.nn.LSTM. 